### PR TITLE
Hide initial requirements on page load

### DIFF
--- a/app/views/players/_player.html.erb
+++ b/app/views/players/_player.html.erb
@@ -2,11 +2,11 @@
   <button data-hiding-target="button" data-action="hiding#toggle" class="button-88">Show requirements</button>
   <div data-hiding-target="hideable" hidden="true">
     <ul>
-    <% player.requirements.each do |requirement| %>
+    <% player.requirements.each_with_index do |requirement, index| %>
       <div data-controller="hiding">
         <li>
-          <button data-hiding-target="button" data-action="hiding#toggle" class="button-90 inline">Hide individual requirement</button>
-          <div data-hiding-target="hideable" class="inline">
+          <button data-hiding-target="button" data-action="hiding#toggle" class="button-90 inline">Show requirement <%= index + 1 %></button>
+          <div data-hiding-target="hideable" class="inline" hidden="true">
             <%= requirement.text %>
           </div>
         </li>


### PR DESCRIPTION
By hiding the initial requirements, we make it possible to support multiple people playing the game on different devices.  A player can now say "I'm showing you my third requirement" and someone on another device can look at just that one requirement.