### PR TITLE
Convert style into strings

### DIFF
--- a/app/models/style.rb
+++ b/app/models/style.rb
@@ -1,5 +1,5 @@
 class Style
-  STYLES = [:modern, :antique, :retro, :unusual]
+  STYLES = ["modern", "antique", "retro", "unusual"]
   def self.random(randomizer: Kernel)
     STYLES[randomizer.rand(4)]
   end

--- a/spec/models/house_spec.rb
+++ b/spec/models/house_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe House, type: :model do
 
   describe "#count_styles" do
     let(:subject) { build(:house) }
-    let(:style) { :modern }
+    let(:style) { "modern" }
     let(:section) { double }
     let(:living_room) { build(:room, room_type: "living_room") }
     let(:bedroom) { build(:room, room_type: "bedroom") }

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe Room, type: :model do
       subject.tokens.append(Lamp.new(color: "red"))
       subject.tokens.append(Curio.new(color: "red"))
       subject.tokens.append(EmptyFurnishing.new)
-      expect(subject.count_styles(:retro)).to eq(1)
-      expect(subject.count_styles(:unusual)).to eq(1)
-      expect(subject.count_styles(:antique)).to eq(0)
+      expect(subject.count_styles("retro")).to eq(1)
+      expect(subject.count_styles("unusual")).to eq(1)
+      expect(subject.count_styles("antique")).to eq(0)
     end
   end
 

--- a/spec/models/style_spec.rb
+++ b/spec/models/style_spec.rb
@@ -8,31 +8,29 @@ RSpec.describe Style do
     context "when random is 0" do
       it "randomly selects modern" do
         expect(randomizer).to receive(:rand).with(4).and_return(0)
-        expect(subject).to eq(:modern)
+        expect(subject).to eq("modern")
       end
     end
 
     context "when random is 1" do
       it "randomly selects antique" do
         expect(randomizer).to receive(:rand).with(4).and_return(1)
-        expect(subject).to eq(:antique)
+        expect(subject).to eq("antique")
       end
     end
 
     context "when random is 2" do
       it "randomly selects retro" do
         expect(randomizer).to receive(:rand).with(4).and_return(2)
-        expect(subject).to eq(:retro)
+        expect(subject).to eq("retro")
       end
     end
 
     context "when random is 3" do
       it "randomly selects unusual" do
         expect(randomizer).to receive(:rand).with(4).and_return(3)
-        expect(subject).to eq(:unusual)
+        expect(subject).to eq("unusual")
       end
     end
   end
 end
-
-


### PR DESCRIPTION
Style is used everywhere as a string - either displayed or stored in the database.  There is no reason to have it as a symbol.