### PR TITLE
Require diverse requirements

### DIFF
--- a/app/models/requirement_generator.rb
+++ b/app/models/requirement_generator.rb
@@ -4,16 +4,19 @@ class RequirementGenerator
   def initialize(players:, requirement_count:, rule_source: ComputedRule)
     self.requirement_list = []
     self.requirement_count = requirement_count
-    (requirement_count * players).times do
+    while requirement_list.count < (requirement_count * players) do
       proposed_rule = rule_source.all.sample
-      self.requirement_list << PrototypeRequirement.new(rule: proposed_rule, feature: proposed_rule.random_feature)
+      proposed_feature = proposed_rule.random_feature
+      if requirement_list.none?{ |pr| pr.rule == proposed_rule && pr.feature == proposed_feature } then
+        self.requirement_list << PrototypeRequirement.new(rule: proposed_rule, feature: proposed_feature)
+      end
     end
   end
 
   def generate_requirements(player:, goal:)
     requirement_count.times do
       req_template = requirement_list.pop
-      player.requirements.append(req_template.rule.build(house: goal))
+      player.requirements.append(req_template.rule.build(house: goal, feature: req_template.feature))
     end
   end
 end

--- a/spec/models/requirement_generator_spec.rb
+++ b/spec/models/requirement_generator_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe RequirementGenerator do
-  let(:subject) { described_class.new(players: 4, requirement_count: 4) }
   describe "#initialize" do
+    let(:subject) { described_class.new(players: 4, requirement_count: 4) }
     it "accepts a count of players and # of requirements per player" do
       expect(subject).to be_instance_of(described_class)
       expect(subject.requirement_count).to eq(4)
@@ -16,23 +16,81 @@ RSpec.describe RequirementGenerator do
   end
 
   describe "#generate_requirements" do
-    let(:player) { instance_double(Player) }
+    let(:first_player) { instance_double(Player) }
+    let(:second_player) { instance_double(Player) }
     let(:goal) { instance_double(House) }
     let(:rule_source) { class_double(ComputedRule) }
-    let(:rule_source_collection) { [computed_rule] }
-    let(:computed_rule) { class_double(ComputedRule::ExactCountOfColor) }
-    let(:finished_rule) { instance_double(Rule) }
-    let(:player_reqs) { [] }
+
+    let(:first_rule) { class_double(ComputedRule::ExactCountOfColor) }
+    let(:second_rule) { class_double(ComputedRule::ExactCountOfFurnishing) }
+    let(:third_rule) { class_double(ComputedRule::RelativeCountOfStyle) }
+    let(:first_finished_rule) { instance_double(Rule) }
+    let(:second_finished_rule) { instance_double(Rule) }
+    let(:third_finished_rule) { instance_double(Rule) }
+    let(:fourth_finished_rule) { instance_double(Rule) }
+
+    let(:order_of_rule_results) {
+      [
+         OpenStruct.new( rule: first_rule,
+                       feature: "red",
+                       result: first_finished_rule ),
+         OpenStruct.new( rule: first_rule,
+                        feature: "red",
+                        result: nil ),
+         OpenStruct.new( rule: first_rule,
+                        feature: "blue",
+                        result: second_finished_rule ),
+         OpenStruct.new( rule: second_rule,
+                        feature: "empty space",
+                        result: third_finished_rule ),
+         OpenStruct.new( rule: first_rule,
+                        feature: "blue",
+                        result: nil ),
+         OpenStruct.new( rule: second_rule,
+                        feature: "empty space",
+                        result: nil ),
+         OpenStruct.new( rule: third_rule,
+                        feature: "modern",
+                        result: fourth_finished_rule )
+      ] }
+
+    let(:uniq_rules) { order_of_rule_results.map(&:rule).uniq }
+    let(:valid_rules) { order_of_rule_results.select { |call| call.result } }
+
+    let(:random_sample_arrays) { order_of_rule_results.map { |call| [call.rule] } }
+
+    let(:first_player_reqs) { [] }
+    let(:second_player_reqs) { [] }
 
     it "generates requirements for that player from the unique requirements list" do
-      allow(rule_source).to receive(:all).exactly(16).times.and_return(rule_source_collection)
-      allow(computed_rule).to receive(:random_feature).exactly(16).times.and_return("sample feature")
-      subject = described_class.new(players: 4, requirement_count: 4, rule_source: rule_source)
-      expect(computed_rule).to receive(:build).with(house: goal).exactly(4).times.and_return(finished_rule)
-      expect(player).to receive(:requirements).exactly(4).times.and_return(player_reqs)
-      subject.generate_requirements(player: player, goal: goal)
-      expect(player_reqs.count).to eq(4)
-      expect(player_reqs).to all(be(finished_rule))
+
+      expect(rule_source).to receive(:all).exactly(7).times.and_return(*random_sample_arrays)
+
+      uniq_rules.each do |rule|
+        attempts_to_use_rule = order_of_rule_results.select { |call| call.rule == rule}
+
+        expect(rule).to receive(:random_feature).exactly(attempts_to_use_rule.count).times.and_return(*attempts_to_use_rule.map(&:feature))
+      end
+
+      subject = described_class.new(players: 2, requirement_count: 2, rule_source: rule_source)
+
+      expect(subject.requirement_list.count).to eq(4)
+
+      valid_rules.last(2).each do |call|
+        expect(call.rule).to receive(:build).with(house: goal, feature: call.feature).and_return(call.result)
+      end
+      expect(first_player).to receive(:requirements).exactly(2).times.and_return(first_player_reqs)
+      subject.generate_requirements(player: first_player, goal: goal)
+      expect(first_player_reqs.count).to eq(2)
+      expect(first_player_reqs).to contain_exactly(third_finished_rule, fourth_finished_rule)
+
+      valid_rules.first(2).each do |call|
+        expect(call.rule).to receive(:build).with(house: goal, feature: call.feature).and_return(call.result)
+      end
+      expect(second_player).to receive(:requirements).exactly(2).times.and_return(second_player_reqs)
+      subject.generate_requirements(player: second_player, goal: goal)
+      expect(second_player_reqs.count).to eq(2)
+      expect(second_player_reqs).to contain_exactly(first_finished_rule, second_finished_rule)
     end
   end
 end


### PR DESCRIPTION
Prevent having two requirements that have the same feature.  Thus, if we have the rule "area X must have more FEATURE than area Y", there can only be one rule for that feature.  We can re-use the rule, but the feature must be different.  This prevents us from having several different rules that are all very similar.