### PR TITLE
Allow players and requirements to be variables

### DIFF
--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -1,6 +1,6 @@
 class ScenariosController < ApplicationController
   def create
-    @scenario = Scenario.build(player_count: scenario_params[:player_count].to_i)
+    @scenario = Scenario.build(player_count: params[:player_count].to_i, requirement_count: params[:requirement_count].to_i)
     redirect_to scenario_url(@scenario)
   end
 
@@ -19,6 +19,6 @@ class ScenariosController < ApplicationController
   private
 
   def scenario_params
-    params.permit(:player_count)
+    params.permit(:player_count, :requirement_count)
   end
 end

--- a/app/views/scenarios/new.html.erb
+++ b/app/views/scenarios/new.html.erb
@@ -1,5 +1,11 @@
 <h1>Create a new scenario</h1>
 
-<%= button_to "Create a 2 player scenario", scenarios_path, method: :post, params: { player_count: "2" } %>
-<%= button_to "Create a 3 player scenario", scenarios_path, method: :post, params: { player_count: "3" } %>
-<%= button_to "Create a 4 player scenario", scenarios_path, method: :post, params: { player_count: "4" } %>
+<%= form_with url: scenarios_path, method: :post do |form| %>
+  <%= form.label :requirement_count, "Requirements per player" %>
+  <%= form.select :requirement_count, ["3","4","5"] %>
+  <br>
+  <%= form.label :player_count, "Number of players" %>
+  <%= form.select :player_count, ["2","3","4","5"] %>
+  <br>
+  <%= form.submit "Create scenario" %>
+<% end %>

--- a/spec/system/start_a_scenario_spec.rb
+++ b/spec/system/start_a_scenario_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe "creating a new scenario", js: true do
 
       expect(current_path).to eq new_scenario_path
 
-      click_on "Create a 2 player scenario"
+      select "4", from: "Requirements per player"
+
+      select "2", from: "Number of players"
+      click_on "Create scenario"
 
       # expect page to be on the choose a player page
       expect(page).to have_content "Starting Layout"


### PR DESCRIPTION
This updates the creation screen to use dropdowns instead of a simple button.  This allows setting the number of requirements per player, and setting the number of players.  (This also allows playing with more players than the normal game allows.)