### PR TITLE
Add fields to Scenario model

### DIFF
--- a/app/models/scenario.rb
+++ b/app/models/scenario.rb
@@ -4,9 +4,9 @@ class Scenario < ApplicationRecord
   belongs_to :goal_layout, class_name: "House"
 
   def self.build(player_count: "2", requirement_count: "4")
-    scenario = new
     req_count = requirement_count.to_i
     player_cnt = player_count.to_i
+    scenario = new(player_count: player_cnt, requirement_count: req_count, likes: 0, dislikes: 0, dont_cares: 0)
     scenario.starting_layout = House.generate(player_count: player_count)
     scenario.goal_layout = House.generate(player_count: player_count)
     requirement_generator = RequirementGenerator.new(players: player_cnt, requirement_count: req_count)

--- a/db/migrate/20241103035305_add_req_count_to_scenario.rb
+++ b/db/migrate/20241103035305_add_req_count_to_scenario.rb
@@ -1,0 +1,5 @@
+class AddReqCountToScenario < ActiveRecord::Migration[7.1]
+  def change
+    add_column :scenarios, :requirement_count, :integer
+  end
+end

--- a/db/migrate/20241103041934_add_ratings_to_scenario.rb
+++ b/db/migrate/20241103041934_add_ratings_to_scenario.rb
@@ -1,0 +1,7 @@
+class AddRatingsToScenario < ActiveRecord::Migration[7.1]
+  def change
+    add_column :scenarios, :likes, :integer
+    add_column :scenarios, :dislikes, :integer
+    add_column :scenarios, :dont_cares, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_10_173700) do
+ActiveRecord::Schema[7.1].define(version: 2024_11_03_041934) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,6 +52,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_10_173700) do
     t.datetime "updated_at", null: false
     t.integer "starting_layout_id"
     t.integer "goal_layout_id"
+    t.integer "requirement_count"
+    t.integer "likes"
+    t.integer "dislikes"
+    t.integer "dont_cares"
   end
 
   create_table "tokens", force: :cascade do |t|


### PR DESCRIPTION
This adds four fields to the Scenario model, only one of which is used at this time: the requirement count.  That is now included so we can show it in the index and people can get an idea of how hard certain games are.  The other fields are in preparation for future changes, when we include the ability to rate scenarios.