### PR TITLE
Fix style count rule and hidden goal button

### DIFF
--- a/app/views/scenarios/show.html.erb
+++ b/app/views/scenarios/show.html.erb
@@ -13,3 +13,13 @@
     </div>
   <% end %>
 </div>
+
+<% if Rails.env.development? %>
+<h2>Goal Layout:</h2>
+<div data-controller="hiding" id="goal-layout">
+  <button data-hiding-target="button" data-action="hiding#toggle">Show goal layout</button>
+  <div data-hiding-target="hideable" hidden="true">
+    <%= render(partial: "houses/house", locals: { house: @scenario.goal_layout }) %>
+  </div>
+</div>
+<% end %>

--- a/spec/models/rules/style_count_spec.rb
+++ b/spec/models/rules/style_count_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe ComputedRule::StyleCount do
         expect(house).to receive(:get_room).with(room_name).and_return(room)
         expect(room).to receive(:lower_name).and_return(room_name)
         expect(room).to receive(:count_different_styles).and_return(count)
-        expect(subject.text).to eq("The kitchen must have two different styles of objects")
+        expect(subject.text).to eq("The kitchen must have exactly two different styles of objects")
       end
     end
 
@@ -54,7 +54,7 @@ RSpec.describe ComputedRule::StyleCount do
         expect(house).to receive(:get_room).with(room_name).and_return(room)
         expect(room).to receive(:lower_name).and_return(room_name)
         expect(room).to receive(:count_different_styles).and_return(count)
-        expect(subject.text).to eq("The kitchen must have three different styles of objects")
+        expect(subject.text).to eq("The kitchen must have exactly three different styles of objects")
       end
     end
   end


### PR DESCRIPTION
2 unrelated changes: the language change to the style count rule didn't update the test, so it was failing; it is useful to see the goal layout when in development, so make that button visible when in that environment.