### PR TITLE
Use warm/cool colors in color based rules

### DIFF
--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -5,8 +5,16 @@ class Color
     ALL.sample
   end
 
+  def self.random_group
+    ALL.append("warm", "cool").sample
+  end
+
   def self.random_color
     new(random)
+  end
+
+  def self.random_colorgroup
+    new(random_group)
   end
 
   attr_reader :color

--- a/app/models/computed_rule/exact_count_of_color.rb
+++ b/app/models/computed_rule/exact_count_of_color.rb
@@ -1,7 +1,7 @@
 module ComputedRule
   class ExactCountOfColor < Requirement
     def self.random_feature
-      Color.random_color
+      Color.random_colorgroup
     end
 
     def self.build(house:, sections: Section, feature:)

--- a/app/models/computed_rule/relative_count_of_color.rb
+++ b/app/models/computed_rule/relative_count_of_color.rb
@@ -1,7 +1,7 @@
 module ComputedRule
   class RelativeCountOfColor < Requirement
     def self.random_feature
-      Color.random_color
+      Color.random_colorgroup
     end
 
     def self.build(house:, sections: Section, feature:)

--- a/spec/models/rules/exact_count_of_color_spec.rb
+++ b/spec/models/rules/exact_count_of_color_spec.rb
@@ -3,15 +3,15 @@ require "rails_helper"
 RSpec.describe ComputedRule::ExactCountOfColor do
   describe ".random_feature" do
     it "calls and returns a random feature" do
-      expect(Color).to receive(:random_color).and_return(Color.new("yellow"))
-      expect(described_class.random_feature.to_s).to eq("yellow")
+      expect(Color).to receive(:random_colorgroup).and_return(Color.new("cool"))
+      expect(described_class.random_feature.to_s).to eq("cool (blue or green)")
     end
   end
 
   describe ".build" do
     let(:house) { instance_double(House) }
     let(:sections) { class_double(Section) }
-    let(:feature) { Color.new("red") }
+    let(:feature) { Color.new("warm") }
     let(:selected_section) { instance_double(Section) }
 
     it "randomly builds a rule from the given house with a given feature" do
@@ -20,7 +20,7 @@ RSpec.describe ComputedRule::ExactCountOfColor do
       expect(house).to receive(:count_colors).with(color: feature, section: selected_section).and_return(3)
       subject = described_class.build(house: house, feature: feature, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain exactly 3 red features (as objects and/or wall colors)")
+      expect(subject.text).to eq("The top floor must contain exactly 3 warm (red or yellow) features (as objects and/or wall colors)")
     end
   end
 end

--- a/spec/models/rules/relative_count_of_color_spec.rb
+++ b/spec/models/rules/relative_count_of_color_spec.rb
@@ -3,15 +3,15 @@ require "rails_helper"
 RSpec.describe ComputedRule::RelativeCountOfColor do
   describe ".random_feature" do
     it "calls and returns a random feature" do
-      expect(Color).to receive(:random_color).and_return(Color.new("yellow"))
-      expect(described_class.random_feature.to_s).to eq("yellow")
+      expect(Color).to receive(:random_colorgroup).and_return(Color.new("cool"))
+      expect(described_class.random_feature.to_s).to eq("cool (blue or green)")
     end
   end
 
   describe ".build" do
     let(:house) { instance_double(House) }
     let(:sections) { class_double(Section) }
-    let(:feature) { Color.new("red") }
+    let(:feature) { Color.new("warm") }
     let(:selected_section) { instance_double(Section) }
     let(:opposite_section) { instance_double(Section) }
 
@@ -24,7 +24,7 @@ RSpec.describe ComputedRule::RelativeCountOfColor do
       expect(house).to receive(:count_colors).with(color: feature, section: opposite_section).and_return(2)
       subject = described_class.build(house: house, feature: feature, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain more red features than the bottom floor (as objects and/or wall colors)")
+      expect(subject.text).to eq("The top floor must contain more warm (red or yellow) features than the bottom floor (as objects and/or wall colors)")
     end
 
     it "randomly builds a rule from the given house when there are less in the first section" do
@@ -36,7 +36,7 @@ RSpec.describe ComputedRule::RelativeCountOfColor do
       expect(house).to receive(:count_colors).with(color: feature, section: opposite_section).and_return(3)
       subject = described_class.build(house: house, feature: feature, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain less red features than the bottom floor (as objects and/or wall colors)")
+      expect(subject.text).to eq("The top floor must contain less warm (red or yellow) features than the bottom floor (as objects and/or wall colors)")
     end
 
     it "randomly builds a rule from the given house when there are an equal amount in both sections" do
@@ -48,7 +48,7 @@ RSpec.describe ComputedRule::RelativeCountOfColor do
       expect(house).to receive(:count_colors).with(color: feature, section: opposite_section).and_return(3)
       subject = described_class.build(house: house, feature: feature, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain an equal amount of red features (as objects and/or wall colors) as the bottom floor")
+      expect(subject.text).to eq("The top floor must contain an equal amount of warm (red or yellow) features (as objects and/or wall colors) as the bottom floor")
     end
   end
 end


### PR DESCRIPTION
The previous work the enable warm/cool colors in the `Color` model made this change easy.