### PR TITLE
Add rule for an exact single furnishing

### DIFF
--- a/app/models/computed_rule/exact_single_furnishing.rb
+++ b/app/models/computed_rule/exact_single_furnishing.rb
@@ -1,0 +1,20 @@
+module ComputedRule
+  class ExactSingleFurnishing < Requirement
+    def self.random_feature
+      Section.random_single
+    end
+
+    def self.build(house:, furnishings: Furnishing, feature:)
+      # select a random type of feature (lamp/curio/wallhanging)
+      # find furnishing in feature, if it exists
+      # if exists, expect furnishing in feature
+      # otherwise, expect furnishing to not exist in feature
+      furnishing_class = furnishings.random_real
+      furnishing = house.get_room(feature.rooms.first).get_furnishing(furnishing_class)
+      rule = create
+      rule.text = (furnishing.class == EmptyFurnishing) ? "The #{feature.name} must not contain a #{furnishing_class.short_name}" : "The #{feature.name} must contain #{furnishing.long_description.downcase}"
+      rule.save
+      rule
+    end
+  end
+end

--- a/app/models/furnishing.rb
+++ b/app/models/furnishing.rb
@@ -3,6 +3,10 @@ class Furnishing < Token
     subclasses.sample
   end
 
+  def self.random_real
+    (subclasses - [EmptyFurnishing]).sample
+  end
+
   def short_name
     self.class.short_name
   end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -32,6 +32,10 @@ class Room < ApplicationRecord
     tokens.count { |token| token.short_name == test_furnishing }
   end
 
+  def get_furnishing(test_furnishing)
+    tokens.to_a.find(lambda { EmptyFurnishing.new }) { |token| token.class == test_furnishing }
+  end
+
   def name
     lower_name.tr("_", " ").titleize
   end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -53,4 +53,8 @@ class Section
   def opposite
     opposite_index ? SECTION_ARRAY[opposite_index] : nil
   end
+
+  def to_s
+    name
+  end
 end

--- a/spec/models/rules/exact_single_furnishing_spec.rb
+++ b/spec/models/rules/exact_single_furnishing_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe ComputedRule::ExactSingleFurnishing do
+  describe ".random_feature" do
+    it "calls and returns a random feature" do
+      expect(Section).to receive(:random_single).and_return(Section.new(7))
+      expect(described_class.random_feature.to_s).to eq("bathroom")
+    end
+  end
+
+  describe ".build" do
+    let(:house) { instance_double(House) }
+    let(:furnishings) { class_double(Furnishing) }
+    let(:room) { instance_double(Room) }
+    let(:specific_type) { Lamp }
+    let(:specific_furnishing) { Lamp.new(color: Color.new("red")) }
+    let(:feature) { Section.new(7) }
+
+    context "when the feature exists in the room" do
+    let(:specific_furnishing) { Lamp.new(color: Color.new("red")) }
+      it "randomly builds a rule from the given house with a given feature" do
+        expect(furnishings).to receive(:random_real).and_return(specific_type)
+        expect(house).to receive(:get_room).with("bathroom").and_return(room)
+        expect(room).to receive(:get_furnishing).with(specific_type).and_return(specific_furnishing)
+        subject = described_class.build(house: house, feature: feature, furnishings: furnishings)
+        expect(subject).to be_a(described_class)
+        expect(subject.text).to eq("The bathroom must contain a red retro lamp")
+      end
+    end
+
+    context "when the feature does not exist in the room" do
+    let(:specific_furnishing) { EmptyFurnishing.new }
+      it "randomly builds a rule from the given house with a given feature" do
+        expect(furnishings).to receive(:random_real).and_return(specific_type)
+        expect(house).to receive(:get_room).with("bathroom").and_return(room)
+        expect(room).to receive(:get_furnishing).with(specific_type).and_return(specific_furnishing)
+        subject = described_class.build(house: house, feature: feature, furnishings: furnishings)
+        expect(subject).to be_a(described_class)
+        expect(subject.text).to eq("The bathroom must not contain a lamp")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This required including a way to get a random furnishing type (ie: `Lamp`, `Curio`, or `WallHanging`), without getting an `EmptyFurnishing`.  It also required having a way to look up a specific furnishing type for a room.

I think there might be some refactoring that needs to be done here. Needing to get specifically the Lamp for a room is going to be more common with some of the later rules, and possibly the Foundational Rules I'm thinking of implementing.  It may be that this will get refactored as I make the `tokens` of `Room` into three separate database properties which point to the individual features of the room.