### PR TITLE
Rework scenario list for mobile responsiveness

### DIFF
--- a/app/assets/stylesheets/default.scss
+++ b/app/assets/stylesheets/default.scss
@@ -33,8 +33,7 @@ margin-top:1%;
   border-radius: 1em;
   -moz-border-radius: 1em;
   -webkit-border-radius: 1em;
-  margin:1em;
-  width: 2em;
+  width: 100%;
   height: 1em;
   text-wrap: nowrap;
 }
@@ -95,7 +94,7 @@ table {
 }
 
 tbody tr {
-  height: 50px;
+  height: 3em;
 }
 
 /* zebra striping */
@@ -113,5 +112,65 @@ tr:nth-child(even) .scenario_list_row{
   .inline {
     display: block;
   }
+
+  /* Force table to not be like tables anymore */
+  table, thead, tbody, th, td, tr {
+    display: block;
+  }
+
+tbody tr {
+  height: 100%;
+}
+
+  /* Hide table headers (but not display: none;, for accessibility) */
+  tr th {
+    position: absolute;
+    top: -99999px;
+    left: -99999px;
+  }
+
+  tr { border: 1px solid #ccc; }
+
+  .scenario_list_row  {
+    /* Behave  like a "row" */
+    border: none;
+    border-bottom: 1px solid #eee;
+    position: relative;
+    padding-left: 50%;
+  }
+
+  .scenario_list_row:before {
+    /* Now like a table header */
+    position: absolute;
+    /* Top/left values mimic padding */
+    top: 6px;
+    left: 6px;
+    width: 45%;
+    padding-right: 10px;
+    white-space: nowrap;
+  }
+
+  /*
+  Label the data
+   */
+
+  .scenario_list_row:nth-of-type(1):before { content: "Scenario #"; }
+  .scenario_list_row:nth-of-type(2):before { content: "Players"; }
+  .scenario_list_row:nth-of-type(3):before { content: "Reqs Per Player"; }
+  .scenario_list_row:nth-of-type(4):before { content: "Start Scenario"; }
+
+.button-small {
+  background-color: #000000;
+  color: #fff;
+  padding: .2em;
+  border-radius: 1em;
+  -moz-border-radius: 1em;
+  -webkit-border-radius: 1em;
+  width: 100%;
+  height: 1em;
+  text-wrap: nowrap;
+}
+
+
 }
 


### PR DESCRIPTION
The big change here is to make the scenario list respond to a small screen by becoming a list instead of a table.

To make this work, I also needed to adjust some of the other settings. One great improvement was removing the specific px setting for the table row height - that was problematic for different display resolutions.