### PR TITLE
Use `singular_rule` rather than `nil`

### DIFF
--- a/app/models/computed_rule/duplicate_furnishing.rb
+++ b/app/models/computed_rule/duplicate_furnishing.rb
@@ -1,7 +1,7 @@
 module ComputedRule
   class DuplicateFurnishing < Requirement
     def self.random_feature
-      nil
+      "singular_rule"
     end
 
     def self.build(house:, feature:)

--- a/spec/models/rules/duplicate_furnishing_spec.rb
+++ b/spec/models/rules/duplicate_furnishing_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe ComputedRule::DuplicateFurnishing do
   describe ".random_feature" do
-    it "always returns nil" do
-      expect(described_class.random_feature).to eq(nil)
+    it "always returns a singlular_rule" do
+      expect(described_class.random_feature).to eq("singular_rule")
     end
   end
 


### PR DESCRIPTION
When creating a computed rule for which there can only be one in the house, we need `random_feature` to somehow indicate that the rule has been taken, and any other attempt to use this rule will be a duplicate of the others.  At first I used `nil` to indicate that there was no random feature for the rule.  However, that isn't very descriptive and in other parts of the code it would not be clear why this feature was returning `nil`.  By making the name a consistent string it is more clear that this is an intended value.