### PR TITLE
Aspect must be most frequent rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- AspectMustBeMostFrequent rule
+
 ## [0.1.1] - 2024-11-26
 
 - TotalColorsInRoom rule

--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :development do
 
   # Speed up commands on slow machines / big apps [https://github.com/rails/spring]
   # gem "spring"
+  gem "spring-commands-rspec"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -371,6 +371,9 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    spring (4.2.1)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -450,6 +453,7 @@ DEPENDENCIES
   rspec-collection_matchers
   rspec-rails
   selenium-webdriver
+  spring-commands-rspec
   sprockets-rails
   standard
   stimulus-rails

--- a/app/models/computed_rule/aspect_must_be_most_frequent.rb
+++ b/app/models/computed_rule/aspect_must_be_most_frequent.rb
@@ -1,0 +1,16 @@
+module ComputedRule
+  class AspectMustBeMostFrequent < Requirement
+    def self.random_feature
+      Furnishing.random_aspect
+    end
+
+    def self.build(house:, feature:)
+      rule = create
+      majority_aspect = house.get_majority(feature)
+      addendum = (feature == "color") ? " (as objects and/or wall color)" : ""
+      rule.text = "No other #{feature} in the house may appear more frequently than #{majority_aspect}#{addendum}"
+      rule.save
+      rule
+    end
+  end
+end

--- a/app/models/furnishing.rb
+++ b/app/models/furnishing.rb
@@ -7,6 +7,10 @@ class Furnishing < Token
     subclasses.reject(&:empty?).sample
   end
 
+  def self.random_aspect
+    ["color", "style", "furnishing"]
+  end
+
   def self.empty?
     false
   end

--- a/app/models/furnishing.rb
+++ b/app/models/furnishing.rb
@@ -8,7 +8,7 @@ class Furnishing < Token
   end
 
   def self.random_aspect
-    ["color", "style", "furnishing"]
+    ["color", "style", "furnishing"].sample
   end
 
   def self.empty?

--- a/app/models/house.rb
+++ b/app/models/house.rb
@@ -49,4 +49,9 @@ class House < ApplicationRecord
       .flatten
       .uniq
   end
+
+  def get_majority(aspect)
+    aspects = rooms.map { |room| room.public_send("#{aspect}_array") }.flatten
+    aspects.max_by { |curr_aspect| aspects.count(curr_aspect) }
+  end
 end

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -17,12 +17,28 @@ class Room < ApplicationRecord
     room
   end
 
-  def count_styles(test_style)
-    tokens.count { |token| token.style == test_style }
-  end
-
   def tokens
     [curio, lamp, wall_hanging]
+  end
+
+  def non_empty_furnishings
+    tokens.reject(&:empty?)
+  end
+
+  def style_array
+    non_empty_furnishings.map(&:style)
+  end
+
+  def color_array
+    non_empty_furnishings.map(&:color).map(&:to_s) + [color.to_s]
+  end
+
+  def furnishing_array
+    non_empty_furnishings.map(&:short_name)
+  end
+
+  def count_styles(test_style)
+    tokens.count { |token| token.style == test_style }
   end
 
   def count_different_styles

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+load File.expand_path("spring", __dir__)
+require 'bundler/setup'
+load Gem.bin_path('rspec-core', 'rspec')

--- a/bin/spring
+++ b/bin/spring
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+
+# This file loads Spring without loading other gems in the Gemfile in order to be fast.
+# It gets overwritten when you run the `spring binstub` command.
+
+if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
+  require "bundler"
+
+  Bundler.locked_gems.specs.find { |spec| spec.name == "spring" }&.tap do |spring|
+    Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
+    gem "spring", spring.version
+    require "spring/binstub"
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,7 +9,7 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # While tests run files are not watched, reloading is not necessary.
-  config.enable_reloading = false
+  config.enable_reloading = true
 
   # Eager loading loads your entire application. When running a single test locally,
   # this is usually not necessary, and can slow down your test suite. However, it's

--- a/spec/models/house_spec.rb
+++ b/spec/models/house_spec.rb
@@ -130,4 +130,53 @@ RSpec.describe House, type: :model do
     end
   end
 
+  describe "#get_majority" do
+    let(:subject) { build(:house) }
+    let(:living_room) { build(:room, room_type: "living_room") }
+    let(:bedroom) { build(:room, room_type: "bedroom") }
+    let(:kitchen) { build(:room, room_type: "kitchen") }
+    let(:bathroom) { build(:room, room_type: "bathroom") }
+
+    context "for color" do
+      it "returns the color that appears the most in all of the rooms" do
+        subject.rooms.append(living_room)
+        subject.rooms.append(bedroom)
+        subject.rooms.append(bathroom)
+        subject.rooms.append(kitchen)
+        expect(living_room).to receive(:color_array).and_return(["blue","red","green"])
+        expect(bedroom).to receive(:color_array).and_return(["yellow","green","green"])
+        expect(kitchen).to receive(:color_array).and_return(["blue","blue","red","green"])
+        expect(bathroom).to receive(:color_array).and_return(["red","green"])
+        expect(subject.get_majority("color")).to eq("green")
+      end
+    end
+
+    context "for style" do
+      it "returns the style that appears the most in all of the rooms" do
+        subject.rooms.append(living_room)
+        subject.rooms.append(bedroom)
+        subject.rooms.append(bathroom)
+        subject.rooms.append(kitchen)
+        expect(living_room).to receive(:style_array).and_return(["modern","modern","retro"])
+        expect(bedroom).to receive(:style_array).and_return(["antique"])
+        expect(kitchen).to receive(:style_array).and_return(["unusual","retro"])
+        expect(bathroom).to receive(:style_array).and_return(["retro"])
+        expect(subject.get_majority("style")).to eq("retro")
+      end
+    end
+
+    context "for furnishing" do
+      it "returns the furnishing that appears the most in all of the rooms" do
+        subject.rooms.append(living_room)
+        subject.rooms.append(bedroom)
+        subject.rooms.append(bathroom)
+        subject.rooms.append(kitchen)
+        expect(living_room).to receive(:furnishing_array).and_return(["lamp","wall hanging","curio"])
+        expect(bedroom).to receive(:furnishing_array).and_return(["lamp"])
+        expect(kitchen).to receive(:furnishing_array).and_return(["wall hanging","curio"])
+        expect(bathroom).to receive(:furnishing_array).and_return(["lamp"])
+        expect(subject.get_majority("furnishing")).to eq("lamp")
+      end
+    end
+  end
 end

--- a/spec/models/room_spec.rb
+++ b/spec/models/room_spec.rb
@@ -93,4 +93,62 @@ RSpec.describe Room, type: :model do
       expect(subject.count_furnishings("wall hanging")).to eq(0)
     end
   end
+
+  describe "#style_array" do
+    let(:subject) { described_class.new }
+
+    it "returns an array of the styles in the room" do
+      subject.lamp = Lamp.new(color: "red")
+      subject.curio = Curio.new(color: "blue")
+      subject.wall_hanging = WallHanging.new(color: "blue")
+      expect(subject.style_array).to contain_exactly("retro","retro","antique")
+    end
+
+    it "returns an empty array if there are no objects in the room" do
+      subject.lamp = EmptyLamp.new
+      subject.curio = EmptyCurio.new
+      subject.wall_hanging = EmptyWallHanging.new
+      expect(subject.style_array).to be_empty
+    end
+  end
+
+  describe "#color_array" do
+    let(:subject) { described_class.new }
+
+    it "returns an array of the colors in the room, including the wall color" do
+      subject.lamp = Lamp.new(color: "red")
+      subject.curio = Curio.new(color: "blue")
+      subject.wall_hanging = WallHanging.new(color: "blue")
+      subject.color = "green"
+      expect(subject.color_array).to contain_exactly("blue","blue","green","red")
+    end
+
+    it "returns the wall color alone if there are no objects in the room" do
+      subject.lamp = EmptyLamp.new
+      subject.curio = EmptyCurio.new
+      subject.wall_hanging = EmptyWallHanging.new
+      subject.color = "green"
+      expect(subject.color_array).to contain_exactly("green")
+    end
+  end
+
+  describe "#furnishing_array" do
+    let(:subject) { described_class.new }
+
+    it "returns an array of the short names of the furnishings in the room" do
+      subject.lamp = Lamp.new(color: "red")
+      subject.curio = Curio.new(color: "blue")
+      subject.wall_hanging = EmptyWallHanging.new
+      expect(subject.furnishing_array).to contain_exactly("lamp","curio")
+    end
+
+    it "returns an empty array if there are no objects in the room" do
+      subject.lamp = EmptyLamp.new
+      subject.curio = EmptyCurio.new
+      subject.wall_hanging = EmptyWallHanging.new
+      expect(subject.furnishing_array).to be_empty
+    end
+  end
+
+
 end

--- a/spec/models/rules/aspect_must_be_most_frequent_spec.rb
+++ b/spec/models/rules/aspect_must_be_most_frequent_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe ComputedRule::AspectMustBeMostFrequent do
+  describe ".random_feature" do
+    it "calls and returns a random aspect type" do
+      expect(Furnishing).to receive(:random_aspect).and_return("color")
+      expect(described_class.random_feature).to eq("color")
+    end
+  end
+
+  describe ".build" do
+    let(:house) { instance_double(House) }
+
+    context "when using the color aspect" do
+      it "builds the rule requiring that the majority color is required to be greater than any other in the house" do
+        expect(house).to receive(:get_majority).with("color").and_return("blue")
+        subject = described_class.build(house: house, feature: "color")
+        expect(subject).to be_a(described_class)
+        expect(subject.text).to eq("No other color in the house may appear more frequently than blue (as objects and/or wall color)")
+      end
+    end
+
+    context "when using the style aspect" do
+      it "builds the rule requiring that the majority style is required to be greater than any other in the house" do
+        expect(house).to receive(:get_majority).with("style").and_return("modern")
+        subject = described_class.build(house: house, feature: "style")
+        expect(subject).to be_a(described_class)
+        expect(subject.text).to eq("No other style in the house may appear more frequently than modern")
+      end
+    end
+
+    context "when using the furnishing aspect" do
+      it "builds the rule requiring that the majority furnishing is required to be greater than any other in the house" do
+        expect(house).to receive(:get_majority).with("furnishing").and_return("lamps")
+        subject = described_class.build(house: house, feature: "furnishing")
+        expect(subject).to be_a(described_class)
+        expect(subject.text).to eq("No other furnishing in the house may appear more frequently than lamps")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add a new rule, which looks to see what aspect (color, style, or furnishing) is most frequent in the house, and then requires that no other aspect appears more frequently than that aspect.

To support this, new methods were added to Room and House, and Furnishing was chosen to be where the random selection of an aspect type.

While working on this, it was taking over a minute to run any tests, and most of that time was spend on loading the files.  This was getting to be really annoying.  I enabled `spring` for rspec, so that I could just use that for testing - and it helps a lot.  Tests are down to about 5 seconds total.