### PR TITLE
Added WallColorCount rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - AspectMustBeMostFrequent rule
+- WallColorCount rule
 
 ## [0.1.1] - 2024-11-26
 

--- a/app/models/computed_rule/aspect_must_be_most_frequent.rb
+++ b/app/models/computed_rule/aspect_must_be_most_frequent.rb
@@ -8,6 +8,9 @@ module ComputedRule
       rule = create
       majority_aspect = house.get_majority(feature)
       addendum = (feature == "color") ? " (as objects and/or wall color)" : ""
+      if feature == "furnishing"
+        majority_aspect = majority_aspect.pluralize
+      end
       rule.text = "No other #{feature} in the house may appear more frequently than #{majority_aspect}#{addendum}"
       rule.save
       rule

--- a/app/models/computed_rule/wall_color_count.rb
+++ b/app/models/computed_rule/wall_color_count.rb
@@ -1,0 +1,24 @@
+module ComputedRule
+  class WallColorCount < Requirement
+    def self.random_feature
+      "singular_rule"
+    end
+
+    def self.build(house:, feature:)
+      rule = create
+
+      rule.text = case house.wall_colors.uniq.count
+                  when 4
+                    "The walls of every room must be painted a different color"
+                  when 3
+                    "There must be exactly three different wall colors"
+                  when 2
+                    "There must be exactly two different wall colors"
+                  else
+                    "The walls of every room must be painted the same color"
+                  end
+      rule.save
+      rule
+    end
+  end
+end

--- a/app/models/house.rb
+++ b/app/models/house.rb
@@ -54,4 +54,8 @@ class House < ApplicationRecord
     aspects = rooms.map { |room| room.public_send("#{aspect}_array") }.flatten
     aspects.max_by { |curr_aspect| aspects.count(curr_aspect) }
   end
+
+  def wall_colors
+    rooms.map(&:color)
+  end
 end

--- a/spec/models/house_spec.rb
+++ b/spec/models/house_spec.rb
@@ -130,6 +130,25 @@ RSpec.describe House, type: :model do
     end
   end
 
+  describe "#wall_colors" do
+    let(:subject) { build(:house) }
+    let(:section) { instance_double(Section) }
+    let(:living_room) { build(:room, room_type: "living_room", color: "red") }
+    let(:bedroom) { build(:room, room_type: "bedroom", color: "blue") }
+    let(:kitchen) { build(:room, room_type: "kitchen", color: "red") }
+    let(:bathroom) { build(:room, room_type: "bathroom", color: "green") }
+
+    it "returns the list of wall colors" do
+      subject.rooms.append(living_room)
+      subject.rooms.append(bedroom)
+      subject.rooms.append(bathroom)
+      subject.rooms.append(kitchen)
+
+      expect(subject.wall_colors).to contain_exactly("red","blue","red","green")
+    end
+
+  end
+
   describe "#get_majority" do
     let(:subject) { build(:house) }
     let(:living_room) { build(:room, room_type: "living_room") }

--- a/spec/models/rules/aspect_must_be_most_frequent_spec.rb
+++ b/spec/models/rules/aspect_must_be_most_frequent_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ComputedRule::AspectMustBeMostFrequent do
 
     context "when using the furnishing aspect" do
       it "builds the rule requiring that the majority furnishing is required to be greater than any other in the house" do
-        expect(house).to receive(:get_majority).with("furnishing").and_return("lamps")
+        expect(house).to receive(:get_majority).with("furnishing").and_return("lamp")
         subject = described_class.build(house: house, feature: "furnishing")
         expect(subject).to be_a(described_class)
         expect(subject.text).to eq("No other furnishing in the house may appear more frequently than lamps")

--- a/spec/models/rules/wall_color_count_spec.rb
+++ b/spec/models/rules/wall_color_count_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe ComputedRule::WallColorCount do
+  describe ".random_feature" do
+    it "calls and returns a singular rule" do
+      expect(described_class.random_feature.to_s).to eq("singular_rule")
+    end
+  end
+
+  describe ".build" do
+    let(:house) { instance_double(House) }
+
+    context "when the house has all four wall colors" do
+      it "builds the rule requiring that there be all four colors in the house" do
+        expect(house).to receive(:wall_colors).and_return(["red", "blue", "green", "yellow"])
+        subject = described_class.build(house: house, feature: "singular_rule")
+        expect(subject).to be_a(described_class)
+        expect(subject.text).to eq("The walls of every room must be painted a different color")
+      end
+    end
+
+    context "when the house has three wall colors" do
+      it "builds the rule requiring that there be three wall colors in the house" do
+        expect(house).to receive(:wall_colors).and_return(["red", "blue", "green", "green"])
+        subject = described_class.build(house: house, feature: "singular_rule")
+        expect(subject).to be_a(described_class)
+        expect(subject.text).to eq("There must be exactly three different wall colors")
+      end
+    end
+
+    context "when the house has two different wall colors" do
+      it "builds the rule requiring that there be two wall colors in the house" do
+        expect(house).to receive(:wall_colors).and_return(["red", "yellow", "yellow", "yellow"])
+        subject = described_class.build(house: house, feature: "singular_rule")
+        expect(subject).to be_a(described_class)
+        expect(subject.text).to eq("There must be exactly two different wall colors")
+      end
+    end
+
+    context "when the house has only one wall color" do
+      it "builds the rule requiring that there be only one wall color in the house" do
+        expect(house).to receive(:wall_colors).and_return(["red", "red", "red", "red"])
+        subject = described_class.build(house: house, feature: "singular_rule")
+        expect(subject).to be_a(described_class)
+        expect(subject.text).to eq("The walls of every room must be painted the same color")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This rule is based on the different colors of the walls - requiring that the number of different wall colors is maintained.

This also fixes the AspectMustBeMostFrequent rule to handle pluralization.