### PR TITLE
Comparable rules for style, color, and furnishings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - AspectMustBeMostFrequent rule
 - WallColorCount rule
+- ComparableCount rules
 
 ## [0.1.1] - 2024-11-26
 

--- a/app/models/computed_rule/comparable_count_of_color_vs_furnishing.rb
+++ b/app/models/computed_rule/comparable_count_of_color_vs_furnishing.rb
@@ -1,0 +1,23 @@
+module ComputedRule
+  class ComparableCountOfColorVsFurnishing < Requirement
+    def self.random_feature
+      "#{Color.random_color}-#{Furnishing.random.short_name}"
+    end
+
+    def self.build(house:, sections: Section, feature:)
+      section = sections.random_multiroom
+      c, furnishing = feature.split("-")
+      color = Color.new(c)
+      color_count = house.count_colors(color: color, section: section)
+      furnishing_count = house.count_furnishings(furnishing: furnishing, section: section)
+      rule = create
+      rule.text = if furnishing_count == color_count
+                    "The #{section.name} must contain an equal number of #{furnishing.pluralize} and #{color} features (as objects and/or wall colors)"
+      else
+        "The #{section.name} must contain #{(furnishing_count < color_count) ? "less" : "more"} #{furnishing.pluralize} than #{color} features (as objects and/or wall colors)"
+      end
+      rule.save
+      rule
+    end
+  end
+end

--- a/app/models/computed_rule/comparable_count_of_color_vs_style.rb
+++ b/app/models/computed_rule/comparable_count_of_color_vs_style.rb
@@ -1,0 +1,23 @@
+module ComputedRule
+  class ComparableCountOfColorVsStyle < Requirement
+    def self.random_feature
+      "#{Color.random_color}-#{Style.random}"
+    end
+
+    def self.build(house:, sections: Section, feature:)
+      section = sections.random_multiroom
+      c, style = feature.split("-")
+      color = Color.new(c)
+      color_count = house.count_colors(color: color, section: section)
+      style_count = house.count_styles(style: style, section: section)
+      rule = create
+      rule.text = if style_count == color_count
+        "The #{section.name} must contain an equal number of #{style} objects and #{color} features (as objects and/or wall colors)"
+      else
+        "The #{section.name} must contain #{(style_count < color_count) ? "less" : "more"} #{style} objects than #{color} features (as objects and/or wall colors)"
+      end
+      rule.save
+      rule
+    end
+  end
+end

--- a/app/models/computed_rule/comparable_count_of_style_vs_furnishing.rb
+++ b/app/models/computed_rule/comparable_count_of_style_vs_furnishing.rb
@@ -1,0 +1,22 @@
+module ComputedRule
+  class ComparableCountOfStyleVsFurnishing < Requirement
+    def self.random_feature
+      "#{Style.random}-#{Furnishing.random.short_name}"
+    end
+
+    def self.build(house:, sections: Section, feature:)
+      section = sections.random_multiroom
+      style, furnishing = feature.split("-")
+      style_count = house.count_styles(style: style, section: section)
+      furnishing_count = house.count_furnishings(furnishing: furnishing, section: section)
+      rule = create
+      rule.text = if furnishing_count == style_count
+                    "The #{section.name} must contain an equal number of #{furnishing.pluralize} and #{style} features"
+      else
+        "The #{section.name} must contain #{(furnishing_count < style_count) ? "less" : "more"} #{furnishing.pluralize} than #{style} features"
+      end
+      rule.save
+      rule
+    end
+  end
+end

--- a/app/models/computed_rule/total_colors_in_room.rb
+++ b/app/models/computed_rule/total_colors_in_room.rb
@@ -14,7 +14,7 @@ module ComputedRule
                   when 4
                     "There must be at least one room in the house with all four colors (as objects and/or wall color)"
                   when 3
-                    "There may not be more than three different colors in any room (as objects and/or wall color)"
+                    "There may not be any room with all four colors in the house (as objects and/or wall color)"
                   when 2
                     "There may not be more than two different colors in any room (as objects and/or wall color)"
                   else

--- a/spec/models/rules/comparable_count_of_color_vs_furnishing_spec.rb
+++ b/spec/models/rules/comparable_count_of_color_vs_furnishing_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe ComputedRule::ComparableCountOfColorVsFurnishing do
+  describe ".random_feature" do
+    it "calls and returns a random color and furnishing" do
+      expect(Color).to receive(:random_color).and_return(Color.new("blue"))
+      expect(Furnishing).to receive(:random).and_return(WallHanging)
+      expect(described_class.random_feature.to_s).to eq("blue-wall hanging")
+    end
+  end
+
+  describe ".build" do
+    let(:house) { instance_double(House) }
+    let(:sections) { class_double(Section) }
+    let(:color) { Color.new("blue") }
+    let(:furnishing) { "wall hanging" }
+    let(:feature) { "blue-wall hanging" }
+    let(:selected_section) { instance_double(Section) }
+
+    it "randomly builds a rule from the given house when there is less of the furnishing than of the color in the section" do
+      expect(sections).to receive(:random_multiroom).and_return(selected_section)
+      expect(selected_section).to receive(:name).and_return("top floor")
+      expect(Color).to receive(:new).with("blue").and_return(color)
+      expect(house).to receive(:count_colors).with(color: color, section: selected_section).and_return(4)
+      expect(house).to receive(:count_furnishings).with(furnishing: furnishing, section: selected_section).and_return(3)
+      subject = described_class.build(house: house, feature: feature, sections: sections)
+      expect(subject).to be_a(described_class)
+      expect(subject.text).to eq("The top floor must contain less wall hangings than blue features (as objects and/or wall colors)")
+    end
+
+    it "randomly builds a rule from the given house when there is more of the furnishing than of the color in the section" do
+      expect(sections).to receive(:random_multiroom).and_return(selected_section)
+      expect(selected_section).to receive(:name).and_return("top floor")
+      expect(Color).to receive(:new).with("blue").and_return(color)
+      expect(house).to receive(:count_colors).with(color: color, section: selected_section).and_return(2)
+      expect(house).to receive(:count_furnishings).with(furnishing: furnishing, section: selected_section).and_return(3)
+      subject = described_class.build(house: house, feature: feature, sections: sections)
+      expect(subject).to be_a(described_class)
+      expect(subject.text).to eq("The top floor must contain more wall hangings than blue features (as objects and/or wall colors)")
+    end
+
+    it "randomly builds a rule from the given house when there is an equal amount of the furnishing and of the color in the section" do
+      expect(sections).to receive(:random_multiroom).and_return(selected_section)
+      expect(selected_section).to receive(:name).and_return("top floor")
+      expect(Color).to receive(:new).with("blue").and_return(color)
+      expect(house).to receive(:count_colors).with(color: color, section: selected_section).and_return(3)
+      expect(house).to receive(:count_furnishings).with(furnishing: furnishing, section: selected_section).and_return(3)
+      subject = described_class.build(house: house, feature: feature, sections: sections)
+      expect(subject).to be_a(described_class)
+      expect(subject.text).to eq("The top floor must contain an equal number of wall hangings and blue features (as objects and/or wall colors)")
+    end
+  end
+end

--- a/spec/models/rules/comparable_count_of_color_vs_style_spec.rb
+++ b/spec/models/rules/comparable_count_of_color_vs_style_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe ComputedRule::ComparableCountOfColorVsStyle do
+  describe ".random_feature" do
+    it "calls and returns a random color and style" do
+      expect(Color).to receive(:random_color).and_return(Color.new("blue"))
+      expect(Style).to receive(:random).and_return("retro")
+      expect(described_class.random_feature.to_s).to eq("blue-retro")
+    end
+  end
+
+  describe ".build" do
+    let(:house) { instance_double(House) }
+    let(:sections) { class_double(Section) }
+    let(:color) { Color.new("blue") }
+    let(:style) { "retro" }
+    let(:feature) { "blue-retro" }
+    let(:selected_section) { instance_double(Section) }
+
+    it "randomly builds a rule from the given house when there is less of the style than of the color in the section" do
+      expect(sections).to receive(:random_multiroom).and_return(selected_section)
+      expect(selected_section).to receive(:name).and_return("top floor")
+      expect(Color).to receive(:new).with("blue").and_return(color)
+      expect(house).to receive(:count_colors).with(color: color, section: selected_section).and_return(4)
+      expect(house).to receive(:count_styles).with(style: style, section: selected_section).and_return(3)
+      subject = described_class.build(house: house, feature: feature, sections: sections)
+      expect(subject).to be_a(described_class)
+      expect(subject.text).to eq("The top floor must contain less retro objects than blue features (as objects and/or wall colors)")
+    end
+
+    it "randomly builds a rule from the given house when there is more of the style than of the color in the section" do
+      expect(sections).to receive(:random_multiroom).and_return(selected_section)
+      expect(selected_section).to receive(:name).and_return("top floor")
+      expect(Color).to receive(:new).with("blue").and_return(color)
+      expect(house).to receive(:count_colors).with(color: color, section: selected_section).and_return(2)
+      expect(house).to receive(:count_styles).with(style: style, section: selected_section).and_return(3)
+      subject = described_class.build(house: house, feature: feature, sections: sections)
+      expect(subject).to be_a(described_class)
+      expect(subject.text).to eq("The top floor must contain more retro objects than blue features (as objects and/or wall colors)")
+    end
+
+    it "randomly builds a rule from the given house when there is an equal amount of the style and of the color in the section" do
+      expect(sections).to receive(:random_multiroom).and_return(selected_section)
+      expect(selected_section).to receive(:name).and_return("top floor")
+      expect(Color).to receive(:new).with("blue").and_return(color)
+      expect(house).to receive(:count_colors).with(color: color, section: selected_section).and_return(3)
+      expect(house).to receive(:count_styles).with(style: style, section: selected_section).and_return(3)
+      subject = described_class.build(house: house, feature: feature, sections: sections)
+      expect(subject).to be_a(described_class)
+      expect(subject.text).to eq("The top floor must contain an equal number of retro objects and blue features (as objects and/or wall colors)")
+    end
+  end
+end

--- a/spec/models/rules/comparable_count_of_style_vs_furnishing_spec.rb
+++ b/spec/models/rules/comparable_count_of_style_vs_furnishing_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe ComputedRule::ComparableCountOfStyleVsFurnishing do
+  describe ".random_feature" do
+    it "calls and returns a random style and furnishing" do
+      expect(Style).to receive(:random).and_return("retro")
+      expect(Furnishing).to receive(:random).and_return(WallHanging)
+      expect(described_class.random_feature.to_s).to eq("retro-wall hanging")
+    end
+  end
+
+  describe ".build" do
+    let(:house) { instance_double(House) }
+    let(:sections) { class_double(Section) }
+    let(:style) { "retro" }
+    let(:furnishing) { "wall hanging" }
+    let(:feature) { "retro-wall hanging" }
+    let(:selected_section) { instance_double(Section) }
+
+    it "randomly builds a rule from the given house when there is less of the furnishing than of the style in the section" do
+      expect(sections).to receive(:random_multiroom).and_return(selected_section)
+      expect(selected_section).to receive(:name).and_return("top floor")
+      expect(house).to receive(:count_styles).with(style: style, section: selected_section).and_return(4)
+      expect(house).to receive(:count_furnishings).with(furnishing: furnishing, section: selected_section).and_return(3)
+      subject = described_class.build(house: house, feature: feature, sections: sections)
+      expect(subject).to be_a(described_class)
+      expect(subject.text).to eq("The top floor must contain less wall hangings than retro features")
+    end
+
+    it "randomly builds a rule from the given house when there is more of the furnishing than of the style in the section" do
+      expect(sections).to receive(:random_multiroom).and_return(selected_section)
+      expect(selected_section).to receive(:name).and_return("top floor")
+      expect(house).to receive(:count_styles).with(style: style, section: selected_section).and_return(2)
+      expect(house).to receive(:count_furnishings).with(furnishing: furnishing, section: selected_section).and_return(3)
+      subject = described_class.build(house: house, feature: feature, sections: sections)
+      expect(subject).to be_a(described_class)
+      expect(subject.text).to eq("The top floor must contain more wall hangings than retro features")
+    end
+
+    it "randomly builds a rule from the given house when there is an equal amount of the furnishing and of the style in the section" do
+      expect(sections).to receive(:random_multiroom).and_return(selected_section)
+      expect(selected_section).to receive(:name).and_return("top floor")
+      expect(house).to receive(:count_styles).with(style: style, section: selected_section).and_return(3)
+      expect(house).to receive(:count_furnishings).with(furnishing: furnishing, section: selected_section).and_return(3)
+      subject = described_class.build(house: house, feature: feature, sections: sections)
+      expect(subject).to be_a(described_class)
+      expect(subject.text).to eq("The top floor must contain an equal number of wall hangings and retro features")
+    end
+  end
+end

--- a/spec/models/rules/total_colors_in_room_spec.rb
+++ b/spec/models/rules/total_colors_in_room_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ComputedRule::TotalColorsInRoom do
         expect(house).to receive(:get_distinct_colors).with(section: room4).and_return([])
         subject = described_class.build(house: house, feature: "singular_rule", sections: sections)
         expect(subject).to be_a(described_class)
-        expect(subject.text).to eq("There may not be more than three different colors in any room (as objects and/or wall color)")
+        expect(subject.text).to eq("There may not be any room with all four colors in the house (as objects and/or wall color)")
       end
     end
 


### PR DESCRIPTION
Compares in a large (two or four rooms) group the count of some aspect (color, style, or furnishing type) vs the
count of a different aspect in that group, and makes a requirement based on the relative counts.

This also updates the wording on the house-wide total colors in a room rule to make the rule more clear.