### PR TITLE
Add color spans to the color text

### DIFF
--- a/app/assets/stylesheets/default.scss
+++ b/app/assets/stylesheets/default.scss
@@ -26,6 +26,19 @@ margin-top:1%;
   display: inline;
 }
 
+.red {
+  color: red;
+}
+.green {
+  color: green;
+}
+.blue {
+  color: blue;
+}
+.yellow {
+  color: #ffc40c;
+}
+
 .button-small {
   background-color: #000000;
   color: #fff;

--- a/app/models/color.rb
+++ b/app/models/color.rb
@@ -34,6 +34,17 @@ class Color
     end
   end
 
+  def display
+    case color
+    when "cool"
+      "cool (<span class=\"blue\">blue</span> or <span class=\"green\">green</span>)"
+    when "warm"
+      "warm (<span class=\"red\">red</span> or <span class=\"yellow\">yellow</span>)"
+    else
+      "<span class=\"#{color}\">#{color}</span>"
+    end.html_safe
+  end
+
   def equal?(other)
     case color
     when "cool"

--- a/app/models/computed_rule/aspect_must_be_most_frequent.rb
+++ b/app/models/computed_rule/aspect_must_be_most_frequent.rb
@@ -8,10 +8,13 @@ module ComputedRule
       rule = create
       majority_aspect = house.get_majority(feature)
       addendum = (feature == "color") ? " (as objects and/or wall color)" : ""
-      if feature == "furnishing"
+      case feature
+      when "color"
+        majority_aspect = Color.new(majority_aspect).display
+      when "furnishing"
         majority_aspect = majority_aspect.pluralize
       end
-      rule.text = "No other #{feature} in the house may appear more frequently than #{majority_aspect}#{addendum}"
+      rule.text = "No other #{feature} in the house may appear more frequently than #{majority_aspect}#{addendum}".html_safe
       rule.save
       rule
     end

--- a/app/models/computed_rule/comparable_count_of_color_vs_furnishing.rb
+++ b/app/models/computed_rule/comparable_count_of_color_vs_furnishing.rb
@@ -12,9 +12,9 @@ module ComputedRule
       furnishing_count = house.count_furnishings(furnishing: furnishing, section: section)
       rule = create
       rule.text = if furnishing_count == color_count
-                    "The #{section.name} must contain an equal number of #{furnishing.pluralize} and #{color} features (as objects and/or wall colors)"
+                    "The #{section.name} must contain an equal number of #{furnishing.pluralize} and #{color.display} features (as objects and/or wall colors)".html_safe
       else
-        "The #{section.name} must contain #{(furnishing_count < color_count) ? "fewer" : "more"} #{furnishing.pluralize} than #{color} features (as objects and/or wall colors)"
+        "The #{section.name} must contain #{(furnishing_count < color_count) ? "fewer" : "more"} #{furnishing.pluralize} than #{color.display} features (as objects and/or wall colors)".html_safe
       end
       rule.save
       rule

--- a/app/models/computed_rule/comparable_count_of_color_vs_style.rb
+++ b/app/models/computed_rule/comparable_count_of_color_vs_style.rb
@@ -12,9 +12,9 @@ module ComputedRule
       style_count = house.count_styles(style: style, section: section)
       rule = create
       rule.text = if style_count == color_count
-        "The #{section.name} must contain an equal number of #{style} objects and #{color} features (as objects and/or wall colors)"
+                    "The #{section.name} must contain an equal number of #{style} objects and #{color.display} features (as objects and/or wall colors)".html_safe
       else
-        "The #{section.name} must contain #{(style_count < color_count) ? "fewer" : "more"} #{style} objects than #{color} features (as objects and/or wall colors)"
+        "The #{section.name} must contain #{(style_count < color_count) ? "fewer" : "more"} #{style} objects than #{color.display} features (as objects and/or wall colors)".html_safe
       end
       rule.save
       rule

--- a/app/models/computed_rule/exact_count_of_color.rb
+++ b/app/models/computed_rule/exact_count_of_color.rb
@@ -1,14 +1,15 @@
 module ComputedRule
   class ExactCountOfColor < Requirement
     def self.random_feature
-      Color.random_colorgroup
+      Color.random_colorgroup.color
     end
 
     def self.build(house:, sections: Section, feature:)
       section = sections.random
-      count = house.count_colors(color: feature, section: section)
+      color = Color.new(feature)
+      count = house.count_colors(color: color, section: section)
       rule = create
-      rule.text = "The #{section.name} must contain exactly #{count} #{feature.to_s} #{"feature".pluralize(count)} (as objects and/or wall colors)"
+      rule.text = "The #{section.name} must contain exactly #{count} #{color.display} #{"feature".pluralize(count)} (as objects and/or wall colors)"
       rule.save
       rule
     end

--- a/app/models/computed_rule/relative_count_of_color.rb
+++ b/app/models/computed_rule/relative_count_of_color.rb
@@ -1,18 +1,19 @@
 module ComputedRule
   class RelativeCountOfColor < Requirement
     def self.random_feature
-      Color.random_colorgroup
+      Color.random_colorgroup.color
     end
 
     def self.build(house:, sections: Section, feature:)
       section = sections.random_opposable
-      count = house.count_colors(color: feature, section: section)
-      opposite_count = house.count_colors(color: feature, section: section.opposite)
+      color = Color.new(feature)
+      count = house.count_colors(color: color, section: section)
+      opposite_count = house.count_colors(color: color, section: section.opposite)
       rule = create
       rule.text = if count == opposite_count
-        "The #{section.name} must contain an equal amount of #{feature} features (as objects and/or wall colors) as the #{section.opposite.name}"
+                    "The #{section.name} must contain an equal amount of #{color.display} features (as objects and/or wall colors) as the #{section.opposite.name}".html_safe
       else
-        "The #{section.name} must contain #{(count < opposite_count) ? "fewer" : "more"} #{feature} features than the #{section.opposite.name} (as objects and/or wall colors)"
+        "The #{section.name} must contain #{(count < opposite_count) ? "fewer" : "more"} #{color.display} features than the #{section.opposite.name} (as objects and/or wall colors)".html_safe
       end
       rule.save
       rule

--- a/app/models/curio.rb
+++ b/app/models/curio.rb
@@ -24,7 +24,7 @@ class Curio < Furnishing
   end
 
   def long_description
-    "A #{color_obj} #{style} curio"
+    "A #{color_obj.display} #{style} curio".html_safe
   end
 
   def color_obj

--- a/app/models/lamp.rb
+++ b/app/models/lamp.rb
@@ -24,7 +24,7 @@ class Lamp < Furnishing
   end
 
   def long_description
-    "A #{color_obj} #{style} lamp"
+    "A #{color_obj.display} #{style} lamp".html_safe
   end
 
   def color_obj

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -81,4 +81,8 @@ class Room < ApplicationRecord
   def floor
     BOTTOM_FLOOR_ROOMS.include?(room_type) ? "bottom" : "top"
   end
+
+  def color_obj
+    @color ||= Color.new(color)
+  end
 end

--- a/app/models/wall_hanging.rb
+++ b/app/models/wall_hanging.rb
@@ -24,7 +24,7 @@ class WallHanging < Furnishing
   end
 
   def long_description
-    "A #{color_obj} #{style} wall hanging"
+    "A #{color_obj.display} #{style} wall hanging".html_safe
   end
 
   def color_obj

--- a/app/views/players/_player.html.erb
+++ b/app/views/players/_player.html.erb
@@ -7,7 +7,7 @@
         <li>
           <button data-hiding-target="button" data-action="hiding#toggle" class="button-90 inline">Show requirement <%= index + 1 %></button>
           <div data-hiding-target="hideable" class="inline" hidden="true">
-            <%= requirement.text %>
+            <%= requirement.text.html_safe %>
           </div>
         </li>
     <% end %>

--- a/app/views/rooms/_room.html.erb
+++ b/app/views/rooms/_room.html.erb
@@ -1,7 +1,7 @@
 <div id="<%= room.room_html_id%>">
   <p>
     <p><%= room.name %></p>
-    <p>Wall color: <%= room.color %></p>
+    <p>Wall color: <%= room.color_obj.display %></p>
     <ul>
       <% room.tokens.each do |token| %>
         <li><%= token.long_description %></li>

--- a/spec/models/color_spec.rb
+++ b/spec/models/color_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Color, type: :model do
       expect(subject.equal?(described_class.new("red"))).to be_truthy
       expect(subject.equal?("blue")).to be_falsey
       expect(subject.equal?(described_class.new("green"))).to be_falsey
+      expect(subject.display).to eq("<span class=\"red\">red<\/span>")
     end
 
     it "correctly creats a warm color" do
@@ -18,6 +19,7 @@ RSpec.describe Color, type: :model do
       expect(subject.equal?(described_class.new("yellow"))).to be_truthy
       expect(subject.equal?("blue")).to be_falsey
       expect(subject.equal?(described_class.new("green"))).to be_falsey
+      expect(subject.display).to eq("warm (<span class=\"red\">red<\/span> or <span class=\"yellow\">yellow<\/span>)")
     end
 
     it "correctly creats a cool color" do
@@ -27,6 +29,7 @@ RSpec.describe Color, type: :model do
       expect(subject.equal?(described_class.new("yellow"))).to be_falsey
       expect(subject.equal?("blue")).to be_truthy
       expect(subject.equal?(described_class.new("green"))).to be_truthy
+      expect(subject.display).to eq("cool (<span class=\"blue\">blue<\/span> or <span class=\"green\">green<\/span>)")
     end
 
     it "can compare a primary color to a descriptor" do

--- a/spec/models/rules/aspect_must_be_most_frequent_spec.rb
+++ b/spec/models/rules/aspect_must_be_most_frequent_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ComputedRule::AspectMustBeMostFrequent do
         expect(house).to receive(:get_majority).with("color").and_return("blue")
         subject = described_class.build(house: house, feature: "color")
         expect(subject).to be_a(described_class)
-        expect(subject.text).to eq("No other color in the house may appear more frequently than blue (as objects and/or wall color)")
+        expect(subject.text).to eq("No other color in the house may appear more frequently than <span class=\"blue\">blue<\/span> (as objects and/or wall color)")
       end
     end
 

--- a/spec/models/rules/comparable_count_of_color_vs_furnishing_spec.rb
+++ b/spec/models/rules/comparable_count_of_color_vs_furnishing_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ComputedRule::ComparableCountOfColorVsFurnishing do
       expect(house).to receive(:count_furnishings).with(furnishing: furnishing, section: selected_section).and_return(3)
       subject = described_class.build(house: house, feature: feature, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain fewer wall hangings than blue features (as objects and/or wall colors)")
+      expect(subject.text).to eq("The top floor must contain fewer wall hangings than <span class=\"blue\">blue<\/span> features (as objects and/or wall colors)")
     end
 
     it "randomly builds a rule from the given house when there is more of the furnishing than of the color in the section" do
@@ -36,7 +36,7 @@ RSpec.describe ComputedRule::ComparableCountOfColorVsFurnishing do
       expect(house).to receive(:count_furnishings).with(furnishing: furnishing, section: selected_section).and_return(3)
       subject = described_class.build(house: house, feature: feature, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain more wall hangings than blue features (as objects and/or wall colors)")
+      expect(subject.text).to eq("The top floor must contain more wall hangings than <span class=\"blue\">blue<\/span> features (as objects and/or wall colors)")
     end
 
     it "randomly builds a rule from the given house when there is an equal amount of the furnishing and of the color in the section" do
@@ -47,7 +47,7 @@ RSpec.describe ComputedRule::ComparableCountOfColorVsFurnishing do
       expect(house).to receive(:count_furnishings).with(furnishing: furnishing, section: selected_section).and_return(3)
       subject = described_class.build(house: house, feature: feature, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain an equal number of wall hangings and blue features (as objects and/or wall colors)")
+      expect(subject.text).to eq("The top floor must contain an equal number of wall hangings and <span class=\"blue\">blue<\/span> features (as objects and/or wall colors)")
     end
   end
 end

--- a/spec/models/rules/comparable_count_of_color_vs_style_spec.rb
+++ b/spec/models/rules/comparable_count_of_color_vs_style_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe ComputedRule::ComparableCountOfColorVsStyle do
       expect(house).to receive(:count_styles).with(style: style, section: selected_section).and_return(3)
       subject = described_class.build(house: house, feature: feature, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain fewer retro objects than blue features (as objects and/or wall colors)")
+      expect(subject.text).to eq("The top floor must contain fewer retro objects than <span class=\"blue\">blue<\/span> features (as objects and/or wall colors)")
     end
 
     it "randomly builds a rule from the given house when there is more of the style than of the color in the section" do
@@ -36,7 +36,7 @@ RSpec.describe ComputedRule::ComparableCountOfColorVsStyle do
       expect(house).to receive(:count_styles).with(style: style, section: selected_section).and_return(3)
       subject = described_class.build(house: house, feature: feature, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain more retro objects than blue features (as objects and/or wall colors)")
+      expect(subject.text).to eq("The top floor must contain more retro objects than <span class=\"blue\">blue<\/span> features (as objects and/or wall colors)")
     end
 
     it "randomly builds a rule from the given house when there is an equal amount of the style and of the color in the section" do
@@ -47,7 +47,7 @@ RSpec.describe ComputedRule::ComparableCountOfColorVsStyle do
       expect(house).to receive(:count_styles).with(style: style, section: selected_section).and_return(3)
       subject = described_class.build(house: house, feature: feature, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain an equal number of retro objects and blue features (as objects and/or wall colors)")
+      expect(subject.text).to eq("The top floor must contain an equal number of retro objects and <span class=\"blue\">blue<\/span> features (as objects and/or wall colors)")
     end
   end
 end

--- a/spec/models/rules/exact_count_of_color_spec.rb
+++ b/spec/models/rules/exact_count_of_color_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ComputedRule::ExactCountOfColor do
   describe ".random_feature" do
     it "calls and returns a random feature" do
       expect(Color).to receive(:random_colorgroup).and_return(Color.new("cool"))
-      expect(described_class.random_feature.to_s).to eq("cool (blue or green)")
+      expect(described_class.random_feature).to eq("cool")
     end
   end
 
@@ -15,12 +15,13 @@ RSpec.describe ComputedRule::ExactCountOfColor do
     let(:selected_section) { instance_double(Section) }
 
     it "randomly builds a rule from the given house with a given feature" do
+      expect(Color).to receive(:new).with("warm").and_return(feature)
       expect(sections).to receive(:random).and_return(selected_section)
       expect(selected_section).to receive(:name).and_return("top floor")
       expect(house).to receive(:count_colors).with(color: feature, section: selected_section).and_return(3)
-      subject = described_class.build(house: house, feature: feature, sections: sections)
+      subject = described_class.build(house: house, feature: feature.color, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain exactly 3 warm (red or yellow) features (as objects and/or wall colors)")
+      expect(subject.text).to eq("The top floor must contain exactly 3 warm (<span class=\"red\">red<\/span> or <span class=\"yellow\">yellow<\/span>) features (as objects and/or wall colors)")
     end
   end
 end

--- a/spec/models/rules/exact_single_furnishing_spec.rb
+++ b/spec/models/rules/exact_single_furnishing_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ComputedRule::ExactSingleFurnishing do
         expect(room).to receive(:get_furnishing).with(specific_type).and_return(specific_furnishing)
         subject = described_class.build(house: house, feature: feature, furnishings: furnishings)
         expect(subject).to be_a(described_class)
-        expect(subject.text).to eq("The bathroom must contain a red retro lamp")
+        expect(subject.text).to eq("The bathroom must contain a <span class=\"red\">red<\/span> retro lamp")
       end
     end
 

--- a/spec/models/rules/relative_count_of_color_spec.rb
+++ b/spec/models/rules/relative_count_of_color_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ComputedRule::RelativeCountOfColor do
   describe ".random_feature" do
     it "calls and returns a random feature" do
       expect(Color).to receive(:random_colorgroup).and_return(Color.new("cool"))
-      expect(described_class.random_feature.to_s).to eq("cool (blue or green)")
+      expect(described_class.random_feature.to_s).to eq("cool")
     end
   end
 
@@ -16,39 +16,42 @@ RSpec.describe ComputedRule::RelativeCountOfColor do
     let(:opposite_section) { instance_double(Section) }
 
     it "randomly builds a rule from the given house when there are more in the first section" do
+      expect(Color).to receive(:new).with("warm").and_return(feature)
       expect(sections).to receive(:random_opposable).and_return(selected_section)
       expect(selected_section).to receive(:name).and_return("top floor")
       expect(selected_section).to receive(:opposite).twice.and_return(opposite_section)
       expect(opposite_section).to receive(:name).and_return("bottom floor")
       expect(house).to receive(:count_colors).with(color: feature, section: selected_section).and_return(3)
       expect(house).to receive(:count_colors).with(color: feature, section: opposite_section).and_return(2)
-      subject = described_class.build(house: house, feature: feature, sections: sections)
+      subject = described_class.build(house: house, feature: feature.color, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain more warm (red or yellow) features than the bottom floor (as objects and/or wall colors)")
+      expect(subject.text).to eq("The top floor must contain more warm (<span class=\"red\">red<\/span> or <span class=\"yellow\">yellow<\/span>) features than the bottom floor (as objects and/or wall colors)")
     end
 
     it "randomly builds a rule from the given house when there are fewer in the first section" do
+      expect(Color).to receive(:new).with("warm").and_return(feature)
       expect(sections).to receive(:random_opposable).and_return(selected_section)
       expect(selected_section).to receive(:name).and_return("top floor")
       expect(selected_section).to receive(:opposite).twice.and_return(opposite_section)
       expect(opposite_section).to receive(:name).and_return("bottom floor")
       expect(house).to receive(:count_colors).with(color: feature, section: selected_section).and_return(1)
       expect(house).to receive(:count_colors).with(color: feature, section: opposite_section).and_return(3)
-      subject = described_class.build(house: house, feature: feature, sections: sections)
+      subject = described_class.build(house: house, feature: feature.color, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain fewer warm (red or yellow) features than the bottom floor (as objects and/or wall colors)")
+      expect(subject.text).to eq("The top floor must contain fewer warm (<span class=\"red\">red<\/span> or <span class=\"yellow\">yellow<\/span>) features than the bottom floor (as objects and/or wall colors)")
     end
 
     it "randomly builds a rule from the given house when there are an equal amount in both sections" do
+      expect(Color).to receive(:new).with("warm").and_return(feature)
       expect(sections).to receive(:random_opposable).and_return(selected_section)
       expect(selected_section).to receive(:name).and_return("top floor")
       expect(selected_section).to receive(:opposite).twice.and_return(opposite_section)
       expect(opposite_section).to receive(:name).and_return("bottom floor")
       expect(house).to receive(:count_colors).with(color: feature, section: selected_section).and_return(3)
       expect(house).to receive(:count_colors).with(color: feature, section: opposite_section).and_return(3)
-      subject = described_class.build(house: house, feature: feature, sections: sections)
+      subject = described_class.build(house: house, feature: feature.color, sections: sections)
       expect(subject).to be_a(described_class)
-      expect(subject.text).to eq("The top floor must contain an equal amount of warm (red or yellow) features (as objects and/or wall colors) as the bottom floor")
+      expect(subject.text).to eq("The top floor must contain an equal amount of warm (<span class=\"red\">red<\/span> or <span class=\"yellow\">yellow<\/span>) features (as objects and/or wall colors) as the bottom floor")
     end
   end
 end

--- a/spec/system/start_a_scenario_spec.rb
+++ b/spec/system/start_a_scenario_spec.rb
@@ -18,22 +18,22 @@ RSpec.describe "creating a new scenario", js: true do
       within "#starting-layout" do
         within "#room-layout-bathroom" do
           furnishings = all(".furnishing")
-          expect(furnishings).to all(match(/A (red|blue|green|yellow) (antique|modern|retro|unusual) (curio|lamp|wall hanging)/)).and have_at_most(3).items
+          expect(furnishings).to all(match(/A <span class="(red|blue|green|yellow)">(red|blue|green|yellow)<\/span> (antique|modern|retro|unusual) (curio|lamp|wall hanging)/)).and have_at_most(3).items
         end
 
         within "#room-layout-bedroom" do
           furnishings = all(".furnishing")
-          expect(furnishings).to all(match(/A (red|blue|green|yellow) (antique|modern|retro|unusual) (curio|lamp|wall hanging)/)).and have_at_most(3).items
+          expect(furnishings).to all(match(/A <span class="(red|blue|green|yellow)">(red|blue|green|yellow)<\/span> (antique|modern|retro|unusual) (curio|lamp|wall hanging)/)).and have_at_most(3).items
         end
 
         within "#room-layout-living-room" do
           furnishings = all(".furnishing")
-          expect(furnishings).to all(match(/A (red|blue|green|yellow) (antique|modern|retro|unusual) (curio|lamp|wall hanging)/)).and have_at_most(3).items
+          expect(furnishings).to all(match(/A <span class="(red|blue|green|yellow)">(red|blue|green|yellow)<\/span> (antique|modern|retro|unusual) (curio|lamp|wall hanging)/)).and have_at_most(3).items
         end
 
         within "#room-layout-kitchen" do
           furnishings = all(".furnishing")
-          expect(furnishings).to all(match(/A (red|blue|green|yellow) (antique|modern|retro|unusual) (curio|lamp|wall hanging)/)).and have_at_most(3).items
+          expect(furnishings).to all(match(/A <span class="(red|blue|green|yellow)">(red|blue|green|yellow)<\/span> (antique|modern|retro|unusual) (curio|lamp|wall hanging)/)).and have_at_most(3).items
         end
       end
 


### PR DESCRIPTION
Whenever we are showing the text for a color, we can now include a `span` element with the class indicating which color to display.

A note on the colors: Most I just used the default, but the default yellow is really hard to read.  Instead I used Mikado Yellow.

Another note: given how the application stores rules, older scenarios that were created before this change will not have rules with the updated color text.